### PR TITLE
Don't create a threaded delay

### DIFF
--- a/ofonocallchannel.cpp
+++ b/ofonocallchannel.cpp
@@ -341,10 +341,9 @@ void oFonoCallChannel::onOfonoCallStateChanged(const QString &state)
         }
         mCallChannel->setCallState(Tp::CallStateEnded, 0, reason, stateDetails);
         // just in case, leave the channel opened for one more second before unregistering from bus
-        QTimer::singleShot(1000, [=]() {
-            Q_EMIT closed();
-            mBaseChannel->close();
-        });
+        QThread::msleep(1000);
+        Q_EMIT closed();
+        mBaseChannel->close();
     } else if (state == "active") {
         qDebug() << "active";
         mHoldIface->setHoldState(Tp::LocalHoldStateUnheld, Tp::LocalHoldStateReasonNone);

--- a/ofonoconferencecallchannel.cpp
+++ b/ofonoconferencecallchannel.cpp
@@ -120,9 +120,8 @@ void oFonoConferenceCallChannel::onChannelSplitted(const QDBusObjectPath &path)
 
         mCallChannel->setCallState(Tp::CallStateEnded, 0, reason, stateDetails);
         // just in case, delay the channel closing by 1 second
-        QTimer::singleShot(1000, [=]() {
-            mBaseChannel->close();
-        });
+        QThread::msleep(1000);
+        mBaseChannel->close();
     }
 }
 


### PR DESCRIPTION
This causes mBaseChannel (in some cases) to be deleted before the timer gets fired.