### PR TITLE
schema: port tempfile to mktemp

### DIFF
--- a/schema/update_schema.sh
+++ b/schema/update_schema.sh
@@ -11,7 +11,7 @@ VERSION_FILE=$3
 VERSION="1"
 LATEST_VERSION="1"
 
-TMPFILE=`tempfile`
+TMPFILE=`mktemp`
 
 SCHEMA_FILE="$SOURCE_DIR/v${VERSION}.sql"
 while [ -e $SCHEMA_FILE ]; do


### PR DESCRIPTION
Since tempfile is deprecated. See also: https://stackoverflow.com/a/18717518.
Switch from _debianutils_ to _coreutils_. Contributes to issue #9.