### PR TITLE
Replace tempfile with mktemp

### DIFF
--- a/schema/update_schema.sh
+++ b/schema/update_schema.sh
@@ -11,7 +11,7 @@ VERSION_FILE=$3
 VERSION="1"
 LATEST_VERSION="1"
 
-TMPFILE=`tempfile`
+TMPFILE=$(mktemp /tmp/telepathy-ofono.XXXXXX)
 
 SCHEMA_FILE="$SOURCE_DIR/v${VERSION}.sql"
 while [ -e $SCHEMA_FILE ]; do


### PR DESCRIPTION
Man page of tempfile says [1]:

       Exclusive creation is not guaranteed when creating  files  on  NFS  partitions.   tempfile
       cannot  make  temporary  directories.   tempfile  is  deprecated; you should use mktemp(1)
       instead.

Additionally, tempfile is part of debianutils which is not installed by default (at least not on Manjaro Linux and Fedora)

[1] https://manpages.ubuntu.com/manpages/bionic/man1/tempfile.1.html